### PR TITLE
Add on-demand model download and consolidate temp files into one directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,32 +44,22 @@ pip install -r requirements.txt
 brew install ffmpeg
 ```
 
-### 2. Download models
+### 2. Models
 
-Pick the models you need from the table below. Click the link, then click "Download" on HuggingFace.
+Models are **downloaded automatically** when you select them for the first time. No manual setup needed.
 
-**Pro Models (1.7B) - Best Quality**
+If you prefer to download models manually beforehand, place them in the `models/` directory:
 
-| Model | Use Case | Download |
-|-------|----------|----------|
-| CustomVoice | Preset voices + emotion control | [Download](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit) |
-| VoiceDesign | Create voices from text description | [Download](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit) |
-| Base | Voice cloning from audio | [Download](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit) |
+```bash
+# Pro Models (1.7B) - Best Quality
+hf download --local-dir models/Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit
+hf download --local-dir models/Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit
+hf download --local-dir models/Qwen3-TTS-12Hz-1.7B-Base-8bit mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit
 
-**Lite Models (0.6B) - Faster, Less RAM**
-
-| Model | Use Case | Download |
-|-------|----------|----------|
-| CustomVoice | Preset voices + emotion control | [Download](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit) |
-| VoiceDesign | Create voices from text description | [Download](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-0.6B-VoiceDesign-8bit) |
-| Base | Voice cloning from audio | [Download](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit) |
-
-Put downloaded folders in `models/`:
-```
-models/
-├── Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit/
-├── Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit/
-└── Qwen3-TTS-12Hz-1.7B-Base-8bit/
+# Lite Models (0.6B) - Faster, Less RAM
+hf download --local-dir models/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit
+hf download --local-dir models/Qwen3-TTS-12Hz-0.6B-Base-8bit mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit
+# Note: 0.6B VoiceDesign is not yet available as an MLX model
 ```
 
 ### 3. Run

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ except ImportError:
 BASE_OUTPUT_DIR = os.path.join(os.getcwd(), "outputs")
 MODELS_DIR = os.path.join(os.getcwd(), "models")
 VOICES_DIR = os.path.join(os.getcwd(), "voices")
+TEMP_DIR = os.path.join(os.getcwd(), "temp")
 
 # Settings
 AUTO_PLAY = True
@@ -72,7 +73,7 @@ def clean_memory():
 
 
 def make_temp_dir():
-    return f"temp_{int(time.time())}"
+    return os.path.join(TEMP_DIR, f"temp_{int(time.time())}")
 
 
 def get_smart_path(folder_name):
@@ -160,7 +161,8 @@ def convert_audio_if_needed(input_path):
         except wave.Error:
             pass
 
-    temp_wav = os.path.join(os.getcwd(), f"temp_convert_{int(time.time())}.wav")
+    os.makedirs(TEMP_DIR, exist_ok=True)
+    temp_wav = os.path.join(TEMP_DIR, f"temp_convert_{int(time.time())}.wav")
     print(f"Converting '{ext}' to WAV...")
 
     cmd = ["ffmpeg", "-y", "-v", "error", "-i", input_path, 
@@ -433,6 +435,7 @@ def main_menu():
 if __name__ == "__main__":
     try:
         os.makedirs(BASE_OUTPUT_DIR, exist_ok=True)
+        os.makedirs(TEMP_DIR, exist_ok=True)
         while True:
             main_menu()
     except KeyboardInterrupt:

--- a/main.py
+++ b/main.py
@@ -45,6 +45,16 @@ MODELS = {
     "6": {"name": "Voice Cloning", "folder": "Qwen3-TTS-12Hz-0.6B-Base-8bit", "mode": "clone_manager", "output_subfolder": "Clones"},
 }
 
+# HuggingFace repo mapping (folder name -> repo ID)
+# All models are from mlx-community, except 0.6B VoiceDesign which doesn't exist yet
+HF_REPOS = {
+    "Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit": "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit",
+    "Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit": "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit",
+    "Qwen3-TTS-12Hz-1.7B-Base-8bit": "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit",
+    "Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit": "mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit",
+    "Qwen3-TTS-12Hz-0.6B-Base-8bit": "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit",
+}
+
 SPEAKER_MAP = {
     "English": ["Ryan", "Aiden", "Ethan", "Chelsie", "Serena", "Vivian"],
     "Chinese": ["Vivian", "Serena", "Uncle_Fu", "Dylan", "Eric"],
@@ -76,10 +86,37 @@ def make_temp_dir():
     return os.path.join(TEMP_DIR, f"temp_{int(time.time())}")
 
 
+def download_model(folder_name):
+    repo_id = HF_REPOS.get(folder_name)
+    if not repo_id:
+        print(f"Error: No download available for '{folder_name}'.")
+        return False
+
+    local_dir = os.path.join(MODELS_DIR, folder_name)
+    print(f"\nModel '{folder_name}' not found locally.")
+    print(f"Downloading from {repo_id} (this may take a while)...")
+
+    try:
+        subprocess.run(
+            ["hf", "download", "--local-dir", local_dir, repo_id],
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+        print("Download complete.")
+        return True
+    except FileNotFoundError:
+        print("Error: 'hf' CLI not found. Install it with: pip install huggingface_hub[cli]")
+        return False
+    except subprocess.CalledProcessError:
+        print("Download failed. Check your internet connection and try again.")
+        return False
+
+
 def get_smart_path(folder_name):
     full_path = os.path.join(MODELS_DIR, folder_name)
     if not os.path.exists(full_path):
-        return None
+        if not download_model(folder_name):
+            return None
 
     snapshots_dir = os.path.join(full_path, "snapshots")
     if os.path.exists(snapshots_dir):


### PR DESCRIPTION
Summary of changes

  - Automatic model downloading: Models are now downloaded on-demand via the hf CLI when selected for the first time, removing the need for manual setup. If a model is missing locally, the app downloads it from HuggingFace automatically. This is mainly a Dev-Experience improvement — having to manually download models before using the app was a bit tedious.
  - Dedicated temp directory: Consolidated all temporary files (audio conversions, processing temp dirs) into a single temp/ directory instead of scattering them in the
  working directory.
  - Simplified README: Updated the model section to reflect automatic downloads. Manual hf download commands are still documented as an optional alternative.

  Note: The 0.6B VoiceDesign model is not yet available as an MLX model (which is why i also removed it from the readme). I will add it to the download mapping as soon as it becomes available.

  What I've tested

  - Run the app and select a model that hasn't been downloaded yet — verify it downloads automatically
  - Run the app with a model already present in models/ — verify it loads without re-downloading
  - Convert a non-WAV audio file and verify the temp file is created inside temp/
  - Verify temp/ and outputs/ directories are created on startup

The tool should now run even more seamless out of the box than it already did.