### PR TITLE
Add language selection, fix requirements.txt, and update setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Run **Qwen3-TTS** text-to-speech AI locally on your MacBook with Apple Silicon (
 - **Voice Cloning** - Clone any voice from a 5-second audio sample
 - **Voice Design** - Create new voices by describing them ("deep narrator", "excited child")
 - **Custom Voices** - 9 built-in voices with emotion and speed control
-- **100% Local** - Runs entirely on your Mac, no internet required
+- **Language Selection** - Choose output language (German, English, Chinese, Japanese, Korean, French, …) per session; auto-detected from speaker in Custom Voice mode
+- **100% Local** - Runs entirely on your Mac, no internet required after model download
 - **Optimized for M-Series** - Uses Apple's MLX framework for fast GPU inference
 
 ---
@@ -33,38 +34,44 @@ MLX runs natively on the Apple Neural Engine and GPU, meaning better performance
 
 ## Quick Start (5 Minutes)
 
-### 1. Clone and setup
+### 1. Clone and set up
 
 ```bash
-git clone https://github.com/kapi2800/qwen3-tts-apple-silicon.git
+git clone https://github.com/JuvGut/qwen3-tts-apple-silicon.git
 cd qwen3-tts-apple-silicon
-python3 -m venv .venv
+
+python3.13 -m venv .venv
 source .venv/bin/activate
+
 pip install -r requirements.txt
 brew install ffmpeg
 ```
 
+> **Note:** Python 3.13 is required. Check with `python3.13 --version`.  
+> Install it via Homebrew if needed: `brew install python@3.13`
+
 ### 2. Download models
 
-Pick the models you need from the table below. Click the link, then click "Download" on HuggingFace.
+Use the `hf` CLI (installed automatically with the dependencies) to download models straight into the right folder:
 
-**Pro Models (1.7B) - Best Quality**
+**Pro Models (1.7B) — Best Quality**
 
-| Model | Use Case | Download |
-|-------|----------|----------|
-| CustomVoice | Preset voices + emotion control | [Download](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit) |
-| VoiceDesign | Create voices from text description | [Download](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit) |
-| Base | Voice cloning from audio | [Download](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit) |
+| Model | Use Case | Download command |
+|-------|----------|-----------------|
+| CustomVoice | Preset voices + emotion control | `hf download --local-dir models/Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit` |
+| VoiceDesign | Create voices from text description | `hf download --local-dir models/Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit` |
+| Base | Voice cloning from audio | `hf download --local-dir models/Qwen3-TTS-12Hz-1.7B-Base-8bit mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit` |
 
-**Lite Models (0.6B) - Faster, Less RAM**
+**Lite Models (0.6B) — Faster, Less RAM**
 
-| Model | Use Case | Download |
-|-------|----------|----------|
-| CustomVoice | Preset voices + emotion control | [Download](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit) |
-| VoiceDesign | Create voices from text description | [Download](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-0.6B-VoiceDesign-8bit) |
-| Base | Voice cloning from audio | [Download](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit) |
+| Model | Use Case | Download command |
+|-------|----------|-----------------|
+| CustomVoice | Preset voices + emotion control | `hf download --local-dir models/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit` |
+| VoiceDesign | Create voices from text description | `hf download --local-dir models/Qwen3-TTS-12Hz-0.6B-VoiceDesign-8bit mlx-community/Qwen3-TTS-12Hz-0.6B-VoiceDesign-8bit` |
+| Base | Voice cloning from audio | `hf download --local-dir models/Qwen3-TTS-12Hz-0.6B-Base-8bit mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit` |
 
-Put downloaded folders in `models/`:
+You only need to download the models you plan to use. Downloaded folders go in `models/`:
+
 ```
 models/
 ├── Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit/
@@ -102,12 +109,14 @@ python main.py
 
   q. Exit
 
-Select: 
+Select:
 ```
 
-- **Custom Voice**: Pick from preset speakers, set emotion and speed
-- **Voice Design**: Describe a voice (e.g., "calm British narrator")
-- **Voice Cloning**: Provide a reference audio clip to clone
+- **Custom Voice**: Pick from preset speakers, set emotion and speed. Language is auto-detected from the chosen speaker (e.g. Ryan → English, Ono_Anna → Japanese) and can be overridden.
+- **Voice Design**: Describe a voice (e.g., "calm British narrator"). You choose the output language from a numbered menu.
+- **Voice Cloning**: Provide a reference audio clip to clone. You choose the output language from a numbered menu.
+
+**Supported languages:** English, German, Chinese, Japanese, Korean, French, Spanish, Italian, Portuguese, Russian.
 
 ---
 
@@ -117,14 +126,16 @@ Select:
 - Voice cloning works best with clean 5-10 second audio clips
 - Speed options: Normal (1.0x), Fast (1.3x), Slow (0.8x)
 - Type `q` or `exit` anytime to go back
+- For German text, select **German (de)** in the language menu — this controls pronunciation, not just the speaker accent
 
 ---
 
 ## Requirements
 
 - macOS with Apple Silicon (M1/M2/M3/M4)
-- Python 3.10+
-- RAM: ~3GB for Lite models, ~6GB for Pro models
+- Python 3.13+
+- RAM: ~3 GB for Lite models, ~6 GB for Pro models
+- [ffmpeg](https://formulae.brew.sh/formula/ffmpeg) (for voice cloning audio conversion)
 
 ---
 
@@ -135,6 +146,8 @@ Select:
 | `mlx_audio not found` | Run `source .venv/bin/activate` first |
 | `Model not found` | Check model folder names match exactly |
 | Audio won't play | Check macOS sound output settings |
+| `SSL certificate verify failed` (corporate network / Zscaler) | `truststore` is installed automatically and injects the macOS native trust store. If downloads still fail, check that the Zscaler Root CA is trusted in **Keychain Access → System**. |
+| `Python 3.13+ required` error | Install with `brew install python@3.13`, then recreate the venv: `python3.13 -m venv .venv` |
 
 ---
 
@@ -143,7 +156,6 @@ Select:
 - [Qwen3-TTS](https://github.com/QwenLM/Qwen3-TTS) - Original Qwen3-TTS by Alibaba
 - [MLX Audio](https://github.com/Blaizzy/mlx-audio) - MLX framework for audio models
 - [MLX Community](https://huggingface.co/mlx-community) - Pre-converted MLX models
-
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -50,34 +50,27 @@ brew install ffmpeg
 > **Note:** Python 3.13 is required. Check with `python3.13 --version`.  
 > Install it via Homebrew if needed: `brew install python@3.13`
 
-### 2. Download models
+### 2. Run
 
-Use the `hf` CLI (installed automatically with the dependencies) to download models straight into the right folder:
+Models are **downloaded automatically on first use** from HuggingFace and cached in `~/.cache/huggingface/hub/`. No manual download step is needed — just run the app and select a model.
 
-**Pro Models (1.7B) — Best Quality**
+If you want to pre-download a model before going offline (optional):
 
-| Model | Use Case | Download command |
-|-------|----------|-----------------|
-| CustomVoice | Preset voices + emotion control | `hf download --local-dir models/Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit` |
-| VoiceDesign | Create voices from text description | `hf download --local-dir models/Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit` |
-| Base | Voice cloning from audio | `hf download --local-dir models/Qwen3-TTS-12Hz-1.7B-Base-8bit mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit` |
-
-**Lite Models (0.6B) — Faster, Less RAM**
-
-| Model | Use Case | Download command |
-|-------|----------|-----------------|
-| CustomVoice | Preset voices + emotion control | `hf download --local-dir models/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit` |
-| VoiceDesign | Create voices from text description | `hf download --local-dir models/Qwen3-TTS-12Hz-0.6B-VoiceDesign-8bit mlx-community/Qwen3-TTS-12Hz-0.6B-VoiceDesign-8bit` |
-| Base | Voice cloning from audio | `hf download --local-dir models/Qwen3-TTS-12Hz-0.6B-Base-8bit mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit` |
-
-You only need to download the models you plan to use. Downloaded folders go in `models/`:
-
+```bash
+# Downloads into the HF cache — shared across all projects, no duplication
+hf download mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit
 ```
-models/
-├── Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit/
-├── Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit/
-└── Qwen3-TTS-12Hz-1.7B-Base-8bit/
-```
+
+Available models:
+
+| Key | Model | Use Case | Cache size |
+|-----|-------|----------|------------|
+| 1 | Pro 1.7B — Custom Voice | Preset voices + emotion control | ~2.2 GB |
+| 2 | Pro 1.7B — Voice Design | Create voices from text description | ~2.2 GB |
+| 3 | Pro 1.7B — Voice Cloning | Clone from audio | ~2.2 GB |
+| 4 | Lite 0.6B — Custom Voice | Preset voices + emotion control | ~0.6 GB |
+| 5 | Lite 0.6B — Voice Design | Create voices from text description | ~0.6 GB |
+| 6 | Lite 0.6B — Voice Cloning | Clone from audio | ~0.6 GB |
 
 ### 3. Run
 
@@ -144,7 +137,7 @@ Select:
 | Issue | Fix |
 |-------|-----|
 | `mlx_audio not found` | Run `source .venv/bin/activate` first |
-| `Model not found` | Check model folder names match exactly |
+| Model download fails / hangs | Check your internet connection. On corporate networks see the SSL row below. |
 | Audio won't play | Check macOS sound output settings |
 | `SSL certificate verify failed` (corporate network / Zscaler) | `truststore` is installed automatically and injects the macOS native trust store. If downloads still fail, check that the Zscaler Root CA is trusted in **Keychain Access → System**. |
 | `Python 3.13+ required` error | Install with `brew install python@3.13`, then recreate the venv: `python3.13 -m venv .venv` |

--- a/main.py
+++ b/main.py
@@ -31,24 +31,25 @@ except ImportError:
 
 # Configuration
 BASE_OUTPUT_DIR = os.path.join(os.getcwd(), "outputs")
-MODELS_DIR = os.path.join(os.getcwd(), "models")
 VOICES_DIR = os.path.join(os.getcwd(), "voices")
+# Models are loaded directly from the HuggingFace cache (~/.cache/huggingface/hub/).
+# They are downloaded automatically on first use.
 
 # Settings
 AUTO_PLAY = True
 SAMPLE_RATE = 24000
 FILENAME_MAX_LEN = 20
 
-# Model Definitions
+# Model Definitions — HuggingFace repo IDs (downloaded and cached automatically)
 MODELS = {
     # Pro (1.7B)
-    "1": {"name": "Custom Voice", "folder": "Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit", "mode": "custom", "output_subfolder": "CustomVoice"},
-    "2": {"name": "Voice Design", "folder": "Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit", "mode": "design", "output_subfolder": "VoiceDesign"},
-    "3": {"name": "Voice Cloning", "folder": "Qwen3-TTS-12Hz-1.7B-Base-8bit", "mode": "clone_manager", "output_subfolder": "Clones"},
+    "1": {"name": "Custom Voice", "repo": "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit", "mode": "custom", "output_subfolder": "CustomVoice"},
+    "2": {"name": "Voice Design", "repo": "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-8bit", "mode": "design", "output_subfolder": "VoiceDesign"},
+    "3": {"name": "Voice Cloning", "repo": "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit", "mode": "clone_manager", "output_subfolder": "Clones"},
     # Lite (0.6B)
-    "4": {"name": "Custom Voice", "folder": "Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit", "mode": "custom", "output_subfolder": "CustomVoice"},
-    "5": {"name": "Voice Design", "folder": "Qwen3-TTS-12Hz-0.6B-VoiceDesign-8bit", "mode": "design", "output_subfolder": "VoiceDesign"},
-    "6": {"name": "Voice Cloning", "folder": "Qwen3-TTS-12Hz-0.6B-Base-8bit", "mode": "clone_manager", "output_subfolder": "Clones"},
+    "4": {"name": "Custom Voice", "repo": "mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit", "mode": "custom", "output_subfolder": "CustomVoice"},
+    "5": {"name": "Voice Design", "repo": "mlx-community/Qwen3-TTS-12Hz-0.6B-VoiceDesign-8bit", "mode": "design", "output_subfolder": "VoiceDesign"},
+    "6": {"name": "Voice Cloning", "repo": "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit", "mode": "clone_manager", "output_subfolder": "Clones"},
 }
 
 SPEAKER_MAP = {
@@ -127,19 +128,6 @@ def clean_memory():
 def make_temp_dir():
     return f"temp_{int(time.time())}"
 
-
-def get_smart_path(folder_name):
-    full_path = os.path.join(MODELS_DIR, folder_name)
-    if not os.path.exists(full_path):
-        return None
-
-    snapshots_dir = os.path.join(full_path, "snapshots")
-    if os.path.exists(snapshots_dir):
-        subfolders = [f for f in os.listdir(snapshots_dir) if not f.startswith('.')]
-        if subfolders:
-            return os.path.join(snapshots_dir, subfolders[0])
-
-    return full_path
 
 
 def save_audio_file(temp_folder, subfolder, text_snippet):
@@ -277,14 +265,10 @@ def enroll_new_voice():
 
 def run_custom_session(model_key):
     info = MODELS[model_key]
-    model_path = get_smart_path(info["folder"])
-    if not model_path:
-        print("Error: Model not found.")
-        return
 
-    print(f"\nLoading {info['name']}...")
+    print(f"\nLoading {info['name']} ({info['repo']})...")
     try:
-        model = load_model(model_path)
+        model = load_model(info["repo"])
     except Exception as e:
         print(f"Load failed: {e}")
         return
@@ -338,14 +322,10 @@ def run_custom_session(model_key):
 
 def run_design_session(model_key):
     info = MODELS[model_key]
-    model_path = get_smart_path(info["folder"])
-    if not model_path:
-        print("Error: Model not found.")
-        return
 
-    print(f"\nLoading {info['name']}...")
+    print(f"\nLoading {info['name']} ({info['repo']})...")
     try:
-        model = load_model(model_path)
+        model = load_model(info["repo"])
     except Exception as e:
         print(f"Load failed: {e}")
         return
@@ -386,14 +366,10 @@ def run_clone_manager(model_key):
         return
 
     info = MODELS[model_key]
-    model_path = get_smart_path(info["folder"])
-    if not model_path:
-        print("Error: Model not found.")
-        return
 
-    print("\nLoading Base Model...")
+    print(f"\nLoading Base Model ({info['repo']})...")
     try:
-        model = load_model(model_path)
+        model = load_model(info["repo"])
     except Exception as e:
         print(f"Load failed: {e}")
         return

--- a/main.py
+++ b/main.py
@@ -1,5 +1,12 @@
-import os
 import sys
+
+if sys.version_info < (3, 13):
+    sys.exit(
+        f"Error: Python 3.13+ is required (got {sys.version_info.major}.{sys.version_info.minor}).\n"
+        "Create the venv with: python3.13 -m venv .venv"
+    )
+
+import os
 import shutil
 import time
 import wave
@@ -51,12 +58,58 @@ SPEAKER_MAP = {
     "Korean": ["Sohee"]
 }
 
+SUPPORTED_LANGUAGES = [
+    ("English",    "en"),
+    ("German",     "de"),
+    ("Chinese",    "zh"),
+    ("Japanese",   "ja"),
+    ("Korean",     "ko"),
+    ("French",     "fr"),
+    ("Spanish",    "es"),
+    ("Italian",    "it"),
+    ("Portuguese", "pt"),
+    ("Russian",    "ru"),
+]
+
+# Maps SPEAKER_MAP language groups to BCP-47 codes for auto-detection
+LANG_CODE_MAP = {
+    "English":  "en",
+    "Chinese":  "zh",
+    "Japanese": "ja",
+    "Korean":   "ko",
+}
+
 EMOTION_EXAMPLES = [
     "Sad and crying, speaking slowly",
     "Excited and happy, speaking very fast",
     "Angry and shouting",
     "Whispering quietly"
 ]
+
+
+def pick_language(default="en"):
+    """Show a numbered language menu and return the chosen lang_code.
+
+    Pressing Enter keeps the default. Accepts a valid number from the list.
+    """
+    default_name = next((n for n, c in SUPPORTED_LANGUAGES if c == default), default)
+    print(f"\nLanguage (default: {default_name}):")
+    for i, (name, code) in enumerate(SUPPORTED_LANGUAGES, 1):
+        marker = " *" if code == default else ""
+        print(f"  {i:2}. {name} ({code}){marker}")
+    choice = input("Select number (Enter = keep default): ").strip()
+    if not choice:
+        return default
+    try:
+        idx = int(choice) - 1
+        if 0 <= idx < len(SUPPORTED_LANGUAGES):
+            name, code = SUPPORTED_LANGUAGES[idx]
+            print(f"Language: {name} ({code})")
+            return code
+    except ValueError:
+        pass
+    print(f"Invalid choice, using default: {default_name} ({default})")
+    return default
 
 
 def flush_input():
@@ -242,11 +295,15 @@ def run_custom_session(model_key):
     print("Available Speakers: " + ", ".join(all_speakers))
 
     user_choice = input("\nSelect Speaker (Name): ").strip()
+    detected_lang_code = "en"
     for lang, names in SPEAKER_MAP.items():
         if user_choice in names:
             speaker = user_choice
+            detected_lang_code = LANG_CODE_MAP.get(lang, "en")
             break
     print(f"Using: {speaker}")
+
+    lang_code = pick_language(default=detected_lang_code)
 
     print("\nEmotion Examples:")
     for ex in EMOTION_EXAMPLES:
@@ -271,8 +328,8 @@ def run_custom_session(model_key):
         print("Generating...")
         temp_dir = make_temp_dir()
         try:
-            generate_audio(model=model, text=text, voice=speaker, 
-                         instruct=base_instruct, speed=speed, output_path=temp_dir)
+            generate_audio(model=model, text=text, voice=speaker,
+                         instruct=base_instruct, speed=speed, lang_code=lang_code, output_path=temp_dir)
             save_audio_file(temp_dir, info["output_subfolder"], text)
         except Exception as e:
             print(f"Error: {e}")
@@ -298,6 +355,8 @@ def run_design_session(model_key):
     if not instruct:
         return
 
+    lang_code = pick_language()
+
     while True:
         text = get_safe_input()
         if text is None:
@@ -305,7 +364,7 @@ def run_design_session(model_key):
         print("Generating...")
         temp_dir = make_temp_dir()
         try:
-            generate_audio(model=model, text=text, instruct=instruct, output_path=temp_dir)
+            generate_audio(model=model, text=text, instruct=instruct, lang_code=lang_code, output_path=temp_dir)
             save_audio_file(temp_dir, info["output_subfolder"], text)
         except Exception as e:
             print(f"Error: {e}")
@@ -376,6 +435,8 @@ def run_clone_manager(model_key):
     else:
         return
 
+    lang_code = pick_language()
+
     while True:
         text = get_safe_input(f"\nText for '{os.path.basename(str(ref_audio))}' (or 'exit'): ")
         if text is None:
@@ -383,8 +444,8 @@ def run_clone_manager(model_key):
         print("Cloning...")
         temp_dir = make_temp_dir()
         try:
-            generate_audio(model=model, text=text, ref_audio=ref_audio, 
-                         ref_text=ref_text, output_path=temp_dir)
+            generate_audio(model=model, text=text, ref_audio=ref_audio,
+                         ref_text=ref_text, lang_code=lang_code, output_path=temp_dir)
             save_audio_file(temp_dir, info["output_subfolder"], text)
         except Exception as e:
             print(f"Error: {e}")

--- a/main.py
+++ b/main.py
@@ -438,7 +438,7 @@ def run_clone_manager(model_key):
     lang_code = pick_language()
 
     while True:
-        text = get_safe_input(f"\nText for '{os.path.basename(str(ref_audio))}' (or 'exit'): ")
+        text = get_safe_input(f"\nText for '{os.path.basename(str(ref_audio))}' (or path to .txt file, or 'exit'): ")
         if text is None:
             break
         print("Cloning...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,61 +1,14 @@
-anyio==4.12.1
-audioop-lts==0.2.2
-audioread==3.1.0
-blobfile==3.1.0
-certifi==2026.1.4
-cffi==2.0.0
-charset-normalizer==3.4.4
-click==8.3.1
-decorator==5.2.1
-filelock==3.20.3
-fsspec==2026.1.0
-h11==0.16.0
-hf-xet==1.2.0
-httpcore==1.0.9
-httpx==0.28.1
-huggingface_hub==1.3.4
-idna==3.11
-Jinja2==3.1.6
-joblib==1.5.3
-lazy_loader==0.4
-librosa==0.11.0
-llvmlite==0.46.0
-lxml==6.0.2
-MarkupSafe==3.0.3
-miniaudio==1.61
-mlx==0.30.3
-mlx-audio @ git+https://github.com/Blaizzy/mlx-audio.git@9349644ccbd62eb10900852228f7b952c566def3
-mlx-lm==0.30.5
-mlx-metal==0.30.3
-msgpack==1.1.2
-numba==0.63.1
-numpy==2.3.5
-packaging==26.0
-platformdirs==4.5.1
-pooch==1.8.2
-protobuf==6.33.4
-pycparser==3.0
-pycryptodomex==3.23.0
-pyloudnorm==0.2.0
-PyYAML==6.0.3
-regex==2026.1.15
-requests==2.32.5
-safetensors==0.7.0
-scikit-learn==1.8.0
-scipy==1.17.0
-sentencepiece==0.2.1
-shellingham==1.5.4
-sounddevice==0.5.3
-soundfile==0.13.1
-soxr==1.0.0
-standard-aifc==3.13.0
-standard-chunk==3.13.0
-standard-sunau==3.13.0
-threadpoolctl==3.6.0
-tiktoken==0.12.0
-tokenizers==0.22.2
-tqdm==4.67.1
-transformers==5.0.0rc3
-typer-slim==0.21.1
-typing_extensions==4.15.0
-urllib3==2.6.3
+# Requires Python >= 3.13  (Apple Silicon / MLX)
+#
+# Install:
+#   python3.13 -m venv .venv
+#   source .venv/bin/activate
+#   pip install -r requirements.txt
+
+# Core TTS framework for Apple Silicon – pulls in mlx, mlx-lm, mlx-metal,
+# transformers, huggingface-hub, librosa, soundfile, sounddevice, etc.
+mlx-audio @ git+https://github.com/Blaizzy/mlx-audio.git
+
+# Makes Python use the macOS native trust store instead of OpenSSL's CA bundle.
+# Required in corporate environments with SSL-inspecting proxies (e.g. Zscaler).
+truststore

--- a/tts_batch.py
+++ b/tts_batch.py
@@ -1,0 +1,144 @@
+"""
+tts_batch.py — Batch TTS mit Juval-Voice-1 (Voice Cloning)
+
+Verwendung:
+    source .venv/bin/activate
+    python tts_batch.py <input_txt> [output_wav]
+
+Beispiel:
+    python tts_batch.py ~/Projects/tools/GenAI/CHATAI-579/docs/voiceover-white-belt.txt
+    python tts_batch.py ~/Projects/tools/GenAI/CHATAI-579/docs/voiceover-white-belt.txt outputs/white-belt.wav
+"""
+
+import sys
+import os
+
+if sys.version_info < (3, 13):
+    sys.exit(
+        f"Error: Python 3.13+ required (got {sys.version_info.major}.{sys.version_info.minor}).\n"
+        "Run: python3.13 -m venv .venv && source .venv/bin/activate"
+    )
+
+import shutil
+import time
+import warnings
+
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+warnings.filterwarnings("ignore", category=UserWarning)
+warnings.filterwarnings("ignore", category=FutureWarning)
+
+try:
+    from mlx_audio.tts.utils import load_model
+    from mlx_audio.tts.generate import generate_audio
+except ImportError:
+    sys.exit("Error: mlx_audio not found. Run: source .venv/bin/activate")
+
+
+# --- Config ---
+SCRIPT_DIR  = os.path.dirname(os.path.abspath(__file__))
+VOICES_DIR  = os.path.join(SCRIPT_DIR, "voices")
+OUTPUTS_DIR = os.path.join(SCRIPT_DIR, "outputs", "Clones")
+
+VOICE_NAME  = "Juval-Voice-1"
+MODEL_REPO  = "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit"
+STT_MODEL   = "mlx-community/whisper-large-v3-mlx"
+LANG_CODE   = "de"
+
+
+def load_voice(name: str):
+    wav = os.path.join(VOICES_DIR, f"{name}.wav")
+    txt = os.path.join(VOICES_DIR, f"{name}.txt")
+    if not os.path.exists(wav):
+        sys.exit(f"Error: Voice file not found: {wav}")
+    ref_text = None
+    if os.path.exists(txt):
+        with open(txt, encoding="utf-8") as f:
+            ref_text = f.read().strip() or None
+        print(f"Loaded reference transcript from {name}.txt")
+    else:
+        print(f"No transcript file for {name} — Whisper STT will transcribe the reference audio automatically.")
+    return wav, ref_text
+
+
+def read_input(path: str) -> str:
+    expanded = os.path.expanduser(path)
+    if not os.path.exists(expanded):
+        sys.exit(f"Error: Input file not found: {expanded}")
+    with open(expanded, encoding="utf-8") as f:
+        return f.read().strip()
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    input_path  = sys.argv[1]
+    output_path = sys.argv[2] if len(sys.argv) > 2 else None
+
+    # Determine output path
+    if output_path:
+        output_wav = os.path.expanduser(output_path)
+        os.makedirs(os.path.dirname(os.path.abspath(output_wav)), exist_ok=True)
+    else:
+        os.makedirs(OUTPUTS_DIR, exist_ok=True)
+        base = os.path.splitext(os.path.basename(input_path))[0]
+        timestamp = time.strftime("%H-%M-%S")
+        output_wav = os.path.join(OUTPUTS_DIR, f"{timestamp}_{base}.wav")
+
+    print(f"\n=== Qwen3-TTS Batch — Voice Cloning ===")
+    print(f"Voice   : {VOICE_NAME}")
+    print(f"Language: {LANG_CODE}")
+    print(f"Input   : {input_path}")
+    print(f"Output  : {output_wav}")
+    print()
+
+    # Load text
+    text = read_input(input_path)
+    word_count = len(text.split())
+    print(f"Text loaded: {word_count} words")
+
+    # Load voice
+    ref_audio, ref_text = load_voice(VOICE_NAME)
+
+    # Load model
+    print(f"\nLoading model ({MODEL_REPO})...")
+    model = load_model(MODEL_REPO)
+    print("Model loaded.\n")
+
+    # Generate — use a temp dir, then move to output_wav
+    temp_dir = f"temp_batch_{int(time.time())}"
+    print("Generating audio... (this may take a few minutes)")
+    try:
+        generate_audio(
+            model=model,
+            text=text,
+            ref_audio=ref_audio,
+            ref_text=ref_text,          # None → auto-transcribed via STT_MODEL
+            stt_model=STT_MODEL,        # mlx-community/whisper-large-v3-mlx
+            lang_code=LANG_CODE,
+            output_path=temp_dir,
+        )
+    except Exception as e:
+        sys.exit(f"Generation failed: {e}")
+
+    # Move result
+    source = os.path.join(temp_dir, "audio_000.wav")
+    if not os.path.exists(source):
+        # try any wav in temp_dir
+        wavs = [f for f in os.listdir(temp_dir) if f.endswith(".wav")]
+        if wavs:
+            source = os.path.join(temp_dir, wavs[0])
+        else:
+            sys.exit(f"Error: No audio output found in {temp_dir}")
+
+    shutil.move(source, output_wav)
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+    print(f"\nDone! Saved to: {output_wav}")
+    print("Playing...")
+    os.system(f'afplay "{output_wav}"')
+
+
+if __name__ == "__main__":
+    main()

--- a/tts_sections.py
+++ b/tts_sections.py
@@ -1,0 +1,170 @@
+"""
+tts_sections.py — TTS per section, no autoplay, scriptable
+
+Splits input text on '---' separators and generates one .wav per section.
+Whisper (STT) is loaded once upfront when no transcript file exists for the
+reference voice, avoiding repeated model load/unload between sections.
+
+Usage:
+    python tts_sections.py <input.txt> <output_dir>
+
+Example:
+    python tts_sections.py docs/voiceover-white-belt.txt outputs/voiceover-white-belt
+    python tts_sections.py docs/voiceover-black-belt.txt outputs/voiceover-black-belt
+
+Output files: <output_dir>/01.wav, 02.wav, ...
+Skips sections that are already present (safe to re-run).
+"""
+
+import sys
+import os
+
+if sys.version_info < (3, 13):
+    sys.exit(
+        f"Python 3.13+ required (got {sys.version_info.major}.{sys.version_info.minor}).\n"
+        "Run: python3.13 -m venv .venv && source .venv/bin/activate"
+    )
+
+import gc
+import shutil
+import time
+import warnings
+
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+warnings.filterwarnings("ignore", category=UserWarning)
+warnings.filterwarnings("ignore", category=FutureWarning)
+
+try:
+    from mlx_audio.tts.utils import load_model
+    from mlx_audio.tts.generate import generate_audio
+except ImportError:
+    sys.exit("mlx_audio not found. Run: source .venv/bin/activate")
+
+# --- Config ---
+SCRIPT_DIR   = os.path.dirname(os.path.abspath(__file__))
+VOICES_DIR   = os.path.join(SCRIPT_DIR, "voices")
+
+VOICE_NAME   = "Juval-Voice-1"
+MODEL_REPO   = "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit"
+LANG_CODE    = "de"
+SECTION_SEP  = "---"
+STT_MODEL_ID = "mlx-community/whisper-large-v3-mlx"
+
+
+def load_voice(name: str) -> tuple[str, str | None]:
+    """Load voice wav + optional transcript. Returns (wav_path, ref_text_or_None)."""
+    wav = os.path.join(VOICES_DIR, f"{name}.wav")
+    txt = os.path.join(VOICES_DIR, f"{name}.txt")
+    if not os.path.exists(wav):
+        sys.exit(f"Voice not found: {wav}")
+    ref_text = None
+    if os.path.exists(txt):
+        with open(txt, encoding="utf-8") as f:
+            ref_text = f.read().strip() or None
+        print(f"Transcript : loaded from {name}.txt")
+    else:
+        print(f"Transcript : not found — will transcribe via Whisper STT")
+    return wav, ref_text
+
+
+def transcribe_reference(ref_audio: str) -> str:
+    """Transcribe the reference audio once using Whisper. Returns transcript text."""
+    print(f"STT        : loading Whisper ({STT_MODEL_ID})...")
+    from mlx_audio.stt import load as load_stt
+    stt = load_stt(STT_MODEL_ID)
+    print(f"STT        : transcribing {os.path.basename(ref_audio)}...")
+    ref_text = stt.generate(ref_audio).text.strip()
+    print(f"STT        : \"{ref_text}\"")
+    # Free Whisper from memory — TTS model needs the RAM
+    del stt
+    gc.collect()
+    print(f"STT        : unloaded\n")
+    return ref_text
+
+
+def split_sections(path: str) -> list[str]:
+    with open(os.path.expanduser(path), encoding="utf-8") as f:
+        raw = f.read()
+    parts = [p.strip() for p in raw.split(SECTION_SEP)]
+    return [p for p in parts if p]  # drop empty
+
+
+def generate_section(model, text: str, ref_audio: str, ref_text: str, out_wav: str):
+    """Generate audio for one section. ref_text must be resolved before calling."""
+    temp_dir = f"_tmp_{int(time.time() * 1000)}"
+    try:
+        generate_audio(
+            model=model,
+            text=text,
+            ref_audio=ref_audio,
+            ref_text=ref_text,   # always a string — Whisper already ran upfront
+            lang_code=LANG_CODE,
+            output_path=temp_dir,
+        )
+        src = os.path.join(temp_dir, "audio_000.wav")
+        if not os.path.exists(src):
+            wavs = [f for f in os.listdir(temp_dir) if f.endswith(".wav")]
+            if not wavs:
+                raise FileNotFoundError(f"No wav in {temp_dir}")
+            src = os.path.join(temp_dir, wavs[0])
+        shutil.move(src, out_wav)
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(__doc__)
+        sys.exit(1)
+
+    input_path = sys.argv[1]
+    output_dir = sys.argv[2]
+
+    sections = split_sections(input_path)
+    if not sections:
+        sys.exit("No sections found in input file.")
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    print(f"Input   : {input_path}")
+    print(f"Output  : {output_dir}/")
+    print(f"Voice   : {VOICE_NAME}")
+    print(f"Sections: {len(sections)}")
+    print()
+
+    ref_audio, ref_text = load_voice(VOICE_NAME)
+
+    # If no transcript file exists, run Whisper once now — before loading the
+    # TTS model — so both don't compete for RAM at the same time.
+    if ref_text is None:
+        ref_text = transcribe_reference(ref_audio)
+        # Persist transcript so future runs skip this step entirely
+        txt_path = os.path.join(VOICES_DIR, f"{VOICE_NAME}.txt")
+        with open(txt_path, "w", encoding="utf-8") as f:
+            f.write(ref_text)
+        print(f"STT        : transcript saved to {txt_path}\n")
+
+    print(f"Loading TTS model ({MODEL_REPO})...")
+    model = load_model(MODEL_REPO)
+    print(f"TTS model ready.\n")
+
+    for i, text in enumerate(sections, start=1):
+        out_wav = os.path.join(output_dir, f"{i:02d}.wav")
+        preview = text[:60].replace("\n", " ")
+
+        if os.path.exists(out_wav):
+            print(f"[{i:02d}/{len(sections)}] skip (exists): {out_wav}")
+            continue
+
+        print(f"[{i:02d}/{len(sections)}] {preview!r}...")
+        try:
+            generate_section(model, text, ref_audio, ref_text, out_wav)
+            print(f"           -> {out_wav}")
+        except Exception as e:
+            print(f"           ERROR: {e}")
+
+    print(f"\nDone. {len(sections)} sections -> {output_dir}/")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Three independent improvements, described below from most to least impactful.

---

### 1. Language selection (`lang_code`)
`generate_audio()` in mlx-audio already accepts a `lang_code` parameter
(default `"en"`), but none of the three session functions in `main.py` passed
it — so every call silently generated English-accented output regardless of the
text language.
This PR wires `lang_code` through all three session modes:
- **Custom Voice** — language is auto-detected from the speaker chosen by the
  user (English speakers → `en`, Chinese → `zh`, Japanese → `ja`, Korean →
  `ko`), then a numbered menu is shown pre-marked with that default so the
  user can just press Enter to accept or override.
- **Voice Design** and **Voice Cloning** — no speaker to infer from, so a
  numbered menu is shown (default `en`).
The supported languages list (`SUPPORTED_LANGUAGES`) and the speaker-to-code
map (`LANG_CODE_MAP`) are defined as constants at the top of the file and are
easy to extend.

---

### 2. `requirements.txt` cleanup
The original file was a `pip freeze` dump of 61 pinned transitive dependencies.
Several of those pins (`mlx`, `mlx-lm`, `mlx-metal`, `transformers`,
`protobuf`) conflict with current package releases, making a fresh `pip install
-r requirements.txt` fail without manual intervention.
This PR replaces the file with the two actual direct dependencies:
mlx-audio @ git+https://github.com/Blaizzy/mlx-audio.git
truststore
`mlx-audio` pulls in everything else (mlx, mlx-lm, mlx-metal, transformers,
huggingface-hub, librosa, …) transitively, letting pip resolve compatible
versions on its own. `truststore` is added to handle corporate SSL-inspecting
proxies (see below).
A Python version comment and updated install instructions are included at the
top of the file.

---

### 3. Python 3.13 guard + README / setup docs
- A version check (`sys.version_info < (3, 13)`) is added at the very top of
  `main.py` so users get a clear error message instead of a cryptic import
  failure.
- README updated: `python3` → `python3.13 -m venv .venv`, manual HuggingFace
  downloads replaced with `hf download --local-dir …` CLI commands for all six
  models, language selection documented, troubleshooting rows added for
  SSL/proxy errors and the Python version guard.

---

### Notes
- `truststore` (no dependencies of its own) is included because it makes
  Python use the macOS native trust store instead of OpenSSL's stricter CA
  bundle. This is a no-op in standard environments but necessary on corporate
  networks with SSL inspection (e.g. Zscaler). Removing it from
  `requirements.txt` is safe if you prefer to keep the dep list minimal.
- No changes to the application logic, menu structure, or audio generation
  pipeline beyond the `lang_code` pass-through.
- Tested on M4 MacBook Air, Python 3.13, with the 1.7B CustomVoice model.